### PR TITLE
feat: add Google Apps Script deployment via clasp

### DIFF
--- a/.clasp.json.example
+++ b/.clasp.json.example
@@ -1,0 +1,4 @@
+{
+  "scriptId": "YOUR_SCRIPT_ID_HERE",
+  "rootDir": "./src/apps-script"
+}

--- a/.claspignore
+++ b/.claspignore
@@ -1,0 +1,14 @@
+**/**
+!src/apps-script/*.gs
+!src/apps-script/appsscript.json
+node_modules/
+.git/
+.env
+.env.*
+!.env.example
+*.md
+.clasp.json.example
+scripts/
+docs/
+src/*
+!src/apps-script/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Google Apps Script Configuration
+# Get SCRIPT_ID from your existing script URL: https://script.google.com/home/projects/SCRIPT_ID/edit
+SCRIPT_ID=1ih6hahfWWHXXaRdZ7gq3VTYSFS8-88mqKJTRJoBm1l363TosDH_y2tWj
+
+# Optional: Deployment ID for production deployments
+# Get this after creating a deployment in the Apps Script editor or via clasp
+DEPLOYMENT_ID=
+
+# For GitHub Actions (stored as repository secrets)
+# CLASP_CREDENTIALS - JSON credentials from ~/.clasprc.json after running 'clasp login'

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -1,0 +1,52 @@
+name: Deploy Google Apps Script
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/apps-script/**'
+      - '.github/workflows/deploy-apps-script.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to Google Apps Script
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Setup clasp authentication
+        run: |
+          echo "${{ secrets.CLASP_CREDENTIALS }}" > ~/.clasprc.json
+          chmod 600 ~/.clasprc.json
+      
+      - name: Setup .clasp.json
+        run: |
+          echo '{
+            "scriptId": "${{ secrets.SCRIPT_ID }}",
+            "rootDir": "./src/apps-script"
+          }' > .clasp.json
+      
+      - name: Push to Google Apps Script
+        run: npm run clasp:push
+      
+      - name: Deploy (if deployment ID is set)
+        if: ${{ secrets.DEPLOYMENT_ID != '' }}
+        run: |
+          DEPLOYMENT_ID="${{ secrets.DEPLOYMENT_ID }}" npm run clasp:deploy
+      
+      - name: Cleanup credentials
+        if: always()
+        run: rm -f ~/.clasprc.json .clasp.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,17 @@
 # SpecStory explanation file
 .specstory/
+
+# Node dependencies
+node_modules/
+
+# Local env files
+.env
+.env.*
+!.env.example
+
+# Clasp configuration
+.clasp.json
+.clasprc.json
+
+# OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -40,6 +40,74 @@ For detailed architecture explanations, see the [ADR directory](docs/adr/).
 
 ## Development
 
+### Google Apps Script Deployment
+
+This project uses [clasp](https://github.com/google/clasp) for deploying Google Apps Script code.
+
+#### Initial Setup
+
+1. **Install dependencies**:
+   ```bash
+   npm install
+   ```
+
+2. **Configure environment**:
+   ```bash
+   cp .env.example .env
+   cp .clasp.json.example .clasp.json
+   ```
+   Edit `.env` and `.clasp.json` with your script ID (from your Apps Script URL).
+
+3. **Authenticate with Google**:
+   ```bash
+   npm run clasp:login
+   ```
+   This will open a browser for authentication. The credentials will be saved to `~/.clasprc.json`.
+
+4. **Run the setup script** (optional):
+   ```bash
+   npm run setup
+   ```
+   This interactive script will help you configure clasp if you prefer guided setup.
+
+#### Deployment Commands
+
+- **Push changes to Apps Script**:
+  ```bash
+  npm run deploy
+  ```
+
+- **Deploy to production** (creates a versioned deployment):
+  ```bash
+  npm run deploy:prod
+  ```
+  Note: Requires `DEPLOYMENT_ID` in your `.env` file.
+
+- **Open in Apps Script editor**:
+  ```bash
+  npm run clasp:open
+  ```
+
+- **Pull latest from Apps Script**:
+  ```bash
+  npm run clasp:pull
+  ```
+
+#### GitHub Actions Deployment
+
+Deployments to Google Apps Script happen automatically when changes are pushed to `main` branch.
+
+**Required GitHub Secrets**:
+1. `SCRIPT_ID`: Your Google Apps Script ID
+2. `CLASP_CREDENTIALS`: Contents of `~/.clasprc.json` after running `clasp login`
+3. `DEPLOYMENT_ID` (optional): For production deployments
+
+To set up GitHub Actions:
+1. Run `clasp login` locally
+2. Copy the contents of `~/.clasprc.json`
+3. Add as `CLASP_CREDENTIALS` secret in GitHub repository settings
+4. Add your `SCRIPT_ID` as a repository secret
+
 ### Architecture Decisions
 
 Key architectural decisions are documented in the [docs/adr/](docs/adr/) directory.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "fire-apps-script",
+  "version": "1.0.0",
+  "description": "Google Apps Script deployment for FIRE financial categorization",
+  "scripts": {
+    "deploy": "npm run clasp:push",
+    "deploy:prod": "npm run clasp:push && npm run clasp:deploy",
+    "clasp:login": "clasp login",
+    "clasp:push": "clasp push",
+    "clasp:deploy": "clasp deploy --deploymentId $DEPLOYMENT_ID",
+    "clasp:open": "clasp open",
+    "clasp:pull": "clasp pull",
+    "setup": "node scripts/setup.js",
+    "postinstall": "echo 'Run npm run setup to configure clasp'"
+  },
+  "devDependencies": {
+    "@google/clasp": "^2.4.2",
+    "dotenv": "^16.0.3"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const readline = require('readline');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+const question = (query) => new Promise((resolve) => rl.question(query, resolve));
+
+async function setup() {
+  console.log('🚀 Google Apps Script Deployment Setup\n');
+
+  // Check if .clasp.json exists
+  const claspJsonPath = path.join(process.cwd(), '.clasp.json');
+  const claspJsonExamplePath = path.join(process.cwd(), '.clasp.json.example');
+  
+  if (!fs.existsSync(claspJsonPath)) {
+    console.log('📋 Setting up .clasp.json...');
+    
+    if (fs.existsSync(claspJsonExamplePath)) {
+      const scriptId = await question('Enter your Google Apps Script ID: ');
+      
+      const claspConfig = {
+        scriptId: scriptId.trim(),
+        rootDir: './src/apps-script'
+      };
+      
+      fs.writeFileSync(claspJsonPath, JSON.stringify(claspConfig, null, 2));
+      console.log('✅ Created .clasp.json\n');
+    }
+  } else {
+    console.log('✅ .clasp.json already exists\n');
+  }
+
+  // Check if .env exists
+  const envPath = path.join(process.cwd(), '.env');
+  const envExamplePath = path.join(process.cwd(), '.env.example');
+  
+  if (!fs.existsSync(envPath) && fs.existsSync(envExamplePath)) {
+    const copyEnv = await question('Would you like to create .env from .env.example? (y/n): ');
+    
+    if (copyEnv.toLowerCase() === 'y') {
+      fs.copyFileSync(envExamplePath, envPath);
+      console.log('✅ Created .env file\n');
+      console.log('📝 Please edit .env with your configuration values\n');
+    }
+  }
+
+  // Check clasp authentication
+  console.log('🔐 Checking clasp authentication...');
+  const clasprcPath = path.join(process.env.HOME || process.env.USERPROFILE, '.clasprc.json');
+  
+  if (!fs.existsSync(clasprcPath)) {
+    console.log('\n⚠️  You need to authenticate with Google');
+    const doAuth = await question('Would you like to authenticate now? (y/n): ');
+    
+    if (doAuth.toLowerCase() === 'y') {
+      console.log('\nRunning clasp login...');
+      console.log('This will open your browser for authentication.\n');
+      
+      try {
+        execSync('npx clasp login', { stdio: 'inherit' });
+        console.log('\n✅ Authentication successful!\n');
+      } catch (error) {
+        console.error('\n❌ Authentication failed:', error.message);
+      }
+    } else {
+      console.log('\n⚠️  Run "npm run clasp:login" when ready to authenticate');
+    }
+  } else {
+    console.log('✅ Already authenticated with Google\n');
+  }
+
+  // Provide next steps
+  console.log('📚 Next steps:');
+  console.log('1. Edit .env and .clasp.json with your configuration');
+  console.log('2. Run "npm run deploy" to push your code to Google Apps Script');
+  console.log('3. Run "npm run clasp:open" to open the Apps Script editor\n');
+
+  rl.close();
+}
+
+setup().catch(console.error);

--- a/src/apps-script/appsscript.json
+++ b/src/apps-script/appsscript.json
@@ -1,0 +1,10 @@
+{
+  "timeZone": "Europe/London",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "MYSELF"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds clasp-based deployment mechanism for Google Apps Script
- Enables automated deployments via GitHub Actions on merge to main
- Provides easy local deployment commands

## Test plan
- [ ] Run `npm install` to install dependencies
- [ ] Copy `.env.example` to `.env` and `.clasp.json.example` to `.clasp.json`
- [ ] Update script ID in configuration files
- [ ] Run `npm run clasp:login` to authenticate
- [ ] Test `npm run deploy` to push changes
- [ ] Verify GitHub Actions workflow runs on merge

🤖 Generated with [Claude Code](https://claude.ai/code)