### PR TITLE
fix: resolve GitHub Actions deployment issues

### DIFF
--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -9,6 +9,10 @@ on:
       - '.github/workflows/deploy-apps-script.yml'
   workflow_dispatch:
 
+env:
+  SCRIPT_ID: '1ih6hahfWWHXXaRdZ7gq3VTYSFS8-88mqKJTRJoBm1l363TosDH_y2tWj'
+  DEPLOYMENT_ID: 'AKfycbyWuGn7rigFDy1CQOVuepcSkaouCbUhNw7aeq07clE'
+
 jobs:
   deploy:
     name: Deploy to Google Apps Script
@@ -34,7 +38,7 @@ jobs:
       - name: Setup .clasp.json
         run: |
           echo '{
-            "scriptId": "${{ secrets.SCRIPT_ID }}",
+            "scriptId": "${{ env.SCRIPT_ID }}",
             "rootDir": "./src/apps-script"
           }' > .clasp.json
       
@@ -42,8 +46,6 @@ jobs:
         run: npm run clasp:push
       
       - name: Deploy (if deployment ID is set)
-        env:
-          DEPLOYMENT_ID: ${{ secrets.DEPLOYMENT_ID }}
         if: env.DEPLOYMENT_ID != ''
         run: npm run clasp:deploy
       

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -2,9 +2,9 @@
 
 ## GitHub Secrets Required
 
-Add these secrets in your GitHub repository (Settings → Secrets and variables → Actions):
+Add this secret in your GitHub repository (Settings → Secrets and variables → Actions):
 
-### 1. CLASP_CREDENTIALS (Required)
+### CLASP_CREDENTIALS (Required)
 Your complete `.clasprc.json` file contents, which includes the refresh token that doesn't expire.
 
 To get this:
@@ -15,13 +15,14 @@ cat ~/.clasprc.json
 
 Copy the entire JSON content and add it as a secret.
 
-### 2. SCRIPT_ID (Required)
-Your Google Apps Script project ID: `1ih6hahfWWHXXaRdZ7gq3VTYSFS8-88mqKJTRJoBm1l363TosDH_y2tWj`
+## Environment Variables
 
-### 3. DEPLOYMENT_ID (Optional)
-Your deployment ID: `AKfycbyWuGn7rigFDy1CQOVuepcSkaouCbUhNw7aeq07clE`
+The following are configured as environment variables in the workflow file since they are not sensitive:
 
-Only add this if you want automatic deployments on push to main.
+- **SCRIPT_ID**: `1ih6hahfWWHXXaRdZ7gq3VTYSFS8-88mqKJTRJoBm1l363TosDH_y2tWj`
+- **DEPLOYMENT_ID**: `AKfycbyWuGn7rigFDy1CQOVuepcSkaouCbUhNw7aeq07clE`
+
+These IDs are public identifiers that appear in Apps Script URLs and are safe to commit to the repository.
 
 ## How It Works
 
@@ -29,7 +30,7 @@ Only add this if you want automatic deployments on push to main.
 2. The refresh token doesn't expire, so CI will continue to work indefinitely
 3. On push to main, the workflow:
    - Pushes code to the Apps Script project
-   - Optionally deploys if `DEPLOYMENT_ID` is set
+   - Deploys the code since `DEPLOYMENT_ID` is set in the workflow
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions secret conditional syntax error
- Moved Script ID and Deployment ID from secrets to environment variables
- Added comprehensive CI setup documentation

## Changes Made
1. **Fixed workflow syntax error**: Changed `${{ secrets.DEPLOYMENT_ID \!= '' }}` to use environment variable approach
2. **Refactored non-sensitive values**: Script ID and Deployment ID are now hardcoded in the workflow as they are public identifiers
3. **Updated documentation**: Created CI setup guide explaining the required GitHub secrets

## Test plan
- [ ] GitHub Actions workflow runs without syntax errors
- [ ] Only `CLASP_CREDENTIALS` needs to be added as a GitHub secret
- [ ] Deployment succeeds when pushing to main branch

🤖 Generated with [Claude Code](https://claude.ai/code)