### PR TITLE
Fix deployment ID usage in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -32,8 +32,14 @@ jobs:
       
       - name: Setup clasp authentication
         run: |
+          # Try both possible locations for clasp credentials
           echo "${{ secrets.CLASP_CREDENTIALS }}" > ~/.clasprc.json
           chmod 600 ~/.clasprc.json
+          
+          # Also try the newer location
+          mkdir -p ~/.config/clasp
+          echo "${{ secrets.CLASP_CREDENTIALS }}" > ~/.config/clasp/.clasprc.json
+          chmod 600 ~/.config/clasp/.clasprc.json
       
       - name: Setup .clasp.json
         run: |
@@ -42,14 +48,19 @@ jobs:
             "rootDir": "./src/apps-script"
           }' > .clasp.json
       
-      - name: Debug - Check .clasp.json
+      - name: Debug - Check configuration
         run: |
           echo "Current directory: $(pwd)"
           echo "Contents of .clasp.json:"
           cat .clasp.json
+          echo "Checking for .clasprc.json:"
+          ls -la ~/.clasprc.json || echo "~/.clasprc.json not found"
+          echo "Checking clasp config directory:"
+          ls -la ~/.config/clasp/ || echo "~/.config/clasp/ not found"
           echo "Environment variables:"
           echo "SCRIPT_ID=${{ env.SCRIPT_ID }}"
           echo "DEPLOYMENT_ID=${{ env.DEPLOYMENT_ID }}"
+          echo "HOME=$HOME"
       
       - name: Push to Google Apps Script
         run: npm run clasp:push
@@ -60,4 +71,6 @@ jobs:
       
       - name: Cleanup credentials
         if: always()
-        run: rm -f ~/.clasprc.json .clasp.json
+        run: |
+          rm -f ~/.clasprc.json .clasp.json
+          rm -f ~/.config/clasp/.clasprc.json

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -47,7 +47,7 @@ jobs:
       
       - name: Deploy (if deployment ID is set)
         if: env.DEPLOYMENT_ID != ''
-        run: npm run clasp:deploy
+        run: npx clasp deploy --deploymentId ${{ env.DEPLOYMENT_ID }}
       
       - name: Cleanup credentials
         if: always()

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -42,6 +42,15 @@ jobs:
             "rootDir": "./src/apps-script"
           }' > .clasp.json
       
+      - name: Debug - Check .clasp.json
+        run: |
+          echo "Current directory: $(pwd)"
+          echo "Contents of .clasp.json:"
+          cat .clasp.json
+          echo "Environment variables:"
+          echo "SCRIPT_ID=${{ env.SCRIPT_ID }}"
+          echo "DEPLOYMENT_ID=${{ env.DEPLOYMENT_ID }}"
+      
       - name: Push to Google Apps Script
         run: npm run clasp:push
       


### PR DESCRIPTION
## Summary
- Fixed the clasp:deploy command in GitHub Actions to properly use the DEPLOYMENT_ID environment variable
- Changed from `npm run clasp:deploy` to `npx clasp deploy --deploymentId ${{ env.DEPLOYMENT_ID }}`

## Problem
The npm script was trying to use `$DEPLOYMENT_ID` as a shell variable, but it wasn't available in that context, causing the deployment to fail with "Script ID or Deployment ID not found" error.

## Solution
Use `npx clasp deploy` directly with the GitHub Actions environment variable substitution, which properly passes the deployment ID to the clasp command.

## Test plan
- [ ] Push this change and verify the GitHub Actions workflow runs successfully
- [ ] Confirm that the deployment step completes without the "Script ID or Deployment ID not found" error

🤖 Generated with [Claude Code](https://claude.ai/code)