### PR TITLE
Fix: CI deployment authentication and read-only deployment issues

### DIFF
--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-main-deploy-debug  # Temporarily added for debugging
     paths:
       - 'src/apps-script/**'
       - '.github/workflows/deploy-apps-script.yml'

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-main-deploy-debug  # Temporary for validation
     paths:
       - 'src/apps-script/**'
       - '.github/workflows/deploy-apps-script.yml'
@@ -55,8 +54,6 @@ jobs:
           
           # Clean up temp file
           rm -f ~/.clasprc.json.tmp
-        env:
-          CLASP_CREDS: ${{ secrets.CLASP_CREDENTIALS }}
           
       - name: Setup .clasp.json
         run: |

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-main-deploy-debug  # Temporary for validation
     paths:
       - 'src/apps-script/**'
       - '.github/workflows/deploy-apps-script.yml'

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-main-deploy-debug  # Temporarily added for debugging
     paths:
       - 'src/apps-script/**'
       - '.github/workflows/deploy-apps-script.yml'
@@ -31,23 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm install
       
-      - name: Debug - Check if CLASP_CREDENTIALS secret exists
-        run: |
-          if [ -z "${{ secrets.CLASP_CREDENTIALS }}" ]; then
-            echo "::error::CLASP_CREDENTIALS secret is empty or not set"
-          else
-            echo "CLASP_CREDENTIALS secret is set (length: ${#CLASP_CREDENTIALS_LENGTH})"
-          fi
-        env:
-          CLASP_CREDENTIALS_LENGTH: ${{ secrets.CLASP_CREDENTIALS }}
-      
       - name: Setup clasp authentication
         run: |
-          # Debug: Check the raw secret format
-          echo "Debug: First 10 chars of secret (base64): $(echo '${{ secrets.CLASP_CREDENTIALS }}' | base64 | head -c 10)"
-          echo "Debug: Length of secret: ${#CLASP_CREDS}"
-          
-          # Try to fix potential JSON issues
+          # Parse and validate JSON credentials
           # Remove potential BOM, trim whitespace, and ensure proper JSON
           echo '${{ secrets.CLASP_CREDENTIALS }}' | sed 's/^\xEF\xBB\xBF//' | tr -d '\r' > ~/.clasprc.json.tmp
           
@@ -72,36 +57,6 @@ jobs:
         env:
           CLASP_CREDS: ${{ secrets.CLASP_CREDENTIALS }}
           
-      - name: Debug - Verify clasp credentials files
-        run: |
-          echo "Checking ~/.clasprc.json:"
-          if [ -f ~/.clasprc.json ]; then
-            echo "File exists"
-            echo "File size: $(stat -c%s ~/.clasprc.json 2>/dev/null || stat -f%z ~/.clasprc.json) bytes"
-            echo "File permissions: $(ls -la ~/.clasprc.json)"
-            echo "First 50 chars (masked): $(head -c 50 ~/.clasprc.json | sed 's/[^{},:]/*/g')"
-            echo "JSON structure check:"
-            if jq empty ~/.clasprc.json 2>/dev/null; then
-              echo "Valid JSON"
-              echo "Top-level keys: $(jq -r 'keys[]' ~/.clasprc.json 2>/dev/null | tr '\n' ' ')"
-            else
-              echo "::error::Invalid JSON in ~/.clasprc.json"
-            fi
-          else
-            echo "::error::~/.clasprc.json file not found"
-          fi
-          
-          echo ""
-          echo "Checking ~/.config/clasp/.clasprc.json:"
-          if [ -f ~/.config/clasp/.clasprc.json ]; then
-            echo "File exists"
-            echo "File size: $(stat -c%s ~/.config/clasp/.clasprc.json 2>/dev/null || stat -f%z ~/.config/clasp/.clasprc.json) bytes"
-            echo "File permissions: $(ls -la ~/.config/clasp/.clasprc.json)"
-            echo "First 50 chars (masked): $(head -c 50 ~/.config/clasp/.clasprc.json | sed 's/[^{},:]/*/g')"
-          else
-            echo "::error::~/.config/clasp/.clasprc.json file not found"
-          fi
-      
       - name: Setup .clasp.json
         run: |
           echo '{
@@ -109,53 +64,8 @@ jobs:
             "rootDir": "./src/apps-script"
           }' > .clasp.json
           
-      - name: Debug - Verify .clasp.json
-        run: |
-          echo "Contents of .clasp.json:"
-          cat .clasp.json
-          echo ""
-          echo "Current directory: $(pwd)"
-          echo "Directory contents:"
-          ls -la
-      
-      - name: Debug - Check clasp installation
-        run: |
-          echo "Clasp version:"
-          npx clasp --version
-          echo ""
-          echo "Node version: $(node --version)"
-          echo "NPM version: $(npm --version)"
-      
-      - name: Debug - Check configuration
-        run: |
-          echo "Current directory: $(pwd)"
-          echo "Contents of .clasp.json:"
-          cat .clasp.json
-          echo "Checking for .clasprc.json:"
-          ls -la ~/.clasprc.json || echo "~/.clasprc.json not found"
-          echo "Checking clasp config directory:"
-          ls -la ~/.config/clasp/ || echo "~/.config/clasp/ not found"
-          echo "Environment variables:"
-          echo "SCRIPT_ID=${{ env.SCRIPT_ID }}"
-          echo "DEPLOYMENT_ID=${{ env.DEPLOYMENT_ID }}"
-          echo "HOME=$HOME"
-      
-      - name: Debug - Test clasp authentication
-        run: |
-          echo "Testing clasp status command:"
-          npx clasp status || echo "clasp status failed"
-          
-          echo ""
-          echo "Trying to list projects:"
-          npx clasp list || echo "clasp list failed"
-          
-          echo ""
-          echo "Check if we need to set CLASP_CREDENTIALS env var:"
-          export CLASP_CREDENTIALS='${{ secrets.CLASP_CREDENTIALS }}'
-          npx clasp status || echo "clasp status with env var failed"
-      
       - name: Push to Google Apps Script
-        run: npm run clasp:push
+        run: npx clasp push --force
       
       - name: Deploy (if deployment ID is set)
         if: env.DEPLOYMENT_ID != ''

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -60,6 +60,13 @@ jobs:
             echo "File size: $(stat -c%s ~/.clasprc.json 2>/dev/null || stat -f%z ~/.clasprc.json) bytes"
             echo "File permissions: $(ls -la ~/.clasprc.json)"
             echo "First 50 chars (masked): $(head -c 50 ~/.clasprc.json | sed 's/[^{},:]/*/g')"
+            echo "JSON structure check:"
+            if jq empty ~/.clasprc.json 2>/dev/null; then
+              echo "Valid JSON"
+              echo "Top-level keys: $(jq -r 'keys[]' ~/.clasprc.json 2>/dev/null | tr '\n' ' ')"
+            else
+              echo "::error::Invalid JSON in ~/.clasprc.json"
+            fi
           else
             echo "::error::~/.clasprc.json file not found"
           fi
@@ -112,6 +119,20 @@ jobs:
           echo "SCRIPT_ID=${{ env.SCRIPT_ID }}"
           echo "DEPLOYMENT_ID=${{ env.DEPLOYMENT_ID }}"
           echo "HOME=$HOME"
+      
+      - name: Debug - Test clasp authentication
+        run: |
+          echo "Testing clasp status command:"
+          npx clasp status || echo "clasp status failed"
+          
+          echo ""
+          echo "Trying to list projects:"
+          npx clasp list || echo "clasp list failed"
+          
+          echo ""
+          echo "Check if we need to set CLASP_CREDENTIALS env var:"
+          export CLASP_CREDENTIALS='${{ secrets.CLASP_CREDENTIALS }}'
+          npx clasp status || echo "clasp status with env var failed"
       
       - name: Push to Google Apps Script
         run: npm run clasp:push

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -43,14 +43,34 @@ jobs:
       
       - name: Setup clasp authentication
         run: |
-          # Try both possible locations for clasp credentials
-          echo "${{ secrets.CLASP_CREDENTIALS }}" > ~/.clasprc.json
+          # Debug: Check the raw secret format
+          echo "Debug: First 10 chars of secret (base64): $(echo '${{ secrets.CLASP_CREDENTIALS }}' | base64 | head -c 10)"
+          echo "Debug: Length of secret: ${#CLASP_CREDS}"
+          
+          # Try to fix potential JSON issues
+          # Remove potential BOM, trim whitespace, and ensure proper JSON
+          echo '${{ secrets.CLASP_CREDENTIALS }}' | sed 's/^\xEF\xBB\xBF//' | tr -d '\r' > ~/.clasprc.json.tmp
+          
+          # Validate and pretty-print JSON
+          if jq . ~/.clasprc.json.tmp > ~/.clasprc.json 2>/dev/null; then
+            echo "Successfully parsed and formatted JSON"
+          else
+            echo "Failed to parse JSON, trying alternative approach"
+            # Try removing outer quotes if they exist
+            echo '${{ secrets.CLASP_CREDENTIALS }}' | sed 's/^"//;s/"$//' | sed 's/^\xEF\xBB\xBF//' | tr -d '\r' > ~/.clasprc.json
+          fi
+          
           chmod 600 ~/.clasprc.json
           
           # Also try the newer location
           mkdir -p ~/.config/clasp
-          echo "${{ secrets.CLASP_CREDENTIALS }}" > ~/.config/clasp/.clasprc.json
+          cp ~/.clasprc.json ~/.config/clasp/.clasprc.json
           chmod 600 ~/.config/clasp/.clasprc.json
+          
+          # Clean up temp file
+          rm -f ~/.clasprc.json.tmp
+        env:
+          CLASP_CREDS: ${{ secrets.CLASP_CREDENTIALS }}
           
       - name: Debug - Verify clasp credentials files
         run: |

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -70,7 +70,11 @@ jobs:
       
       - name: Deploy (if deployment ID is set)
         if: env.DEPLOYMENT_ID != ''
-        run: npx clasp deploy --deploymentId ${{ env.DEPLOYMENT_ID }}
+        run: |
+          echo "Note: The deployment ${{ env.DEPLOYMENT_ID }} appears to be read-only."
+          echo "This typically means it's a HEAD deployment or was created manually."
+          echo "Creating a new versioned deployment instead..."
+          npx clasp deploy --description "GitHub Actions deployment $(date +'%Y-%m-%d %H:%M:%S')"
       
       - name: Cleanup credentials
         if: always()

--- a/.github/workflows/deploy-apps-script.yml
+++ b/.github/workflows/deploy-apps-script.yml
@@ -31,6 +31,16 @@ jobs:
       - name: Install dependencies
         run: npm install
       
+      - name: Debug - Check if CLASP_CREDENTIALS secret exists
+        run: |
+          if [ -z "${{ secrets.CLASP_CREDENTIALS }}" ]; then
+            echo "::error::CLASP_CREDENTIALS secret is empty or not set"
+          else
+            echo "CLASP_CREDENTIALS secret is set (length: ${#CLASP_CREDENTIALS_LENGTH})"
+          fi
+        env:
+          CLASP_CREDENTIALS_LENGTH: ${{ secrets.CLASP_CREDENTIALS }}
+      
       - name: Setup clasp authentication
         run: |
           # Try both possible locations for clasp credentials
@@ -41,6 +51,29 @@ jobs:
           mkdir -p ~/.config/clasp
           echo "${{ secrets.CLASP_CREDENTIALS }}" > ~/.config/clasp/.clasprc.json
           chmod 600 ~/.config/clasp/.clasprc.json
+          
+      - name: Debug - Verify clasp credentials files
+        run: |
+          echo "Checking ~/.clasprc.json:"
+          if [ -f ~/.clasprc.json ]; then
+            echo "File exists"
+            echo "File size: $(stat -c%s ~/.clasprc.json 2>/dev/null || stat -f%z ~/.clasprc.json) bytes"
+            echo "File permissions: $(ls -la ~/.clasprc.json)"
+            echo "First 50 chars (masked): $(head -c 50 ~/.clasprc.json | sed 's/[^{},:]/*/g')"
+          else
+            echo "::error::~/.clasprc.json file not found"
+          fi
+          
+          echo ""
+          echo "Checking ~/.config/clasp/.clasprc.json:"
+          if [ -f ~/.config/clasp/.clasprc.json ]; then
+            echo "File exists"
+            echo "File size: $(stat -c%s ~/.config/clasp/.clasprc.json 2>/dev/null || stat -f%z ~/.config/clasp/.clasprc.json) bytes"
+            echo "File permissions: $(ls -la ~/.config/clasp/.clasprc.json)"
+            echo "First 50 chars (masked): $(head -c 50 ~/.config/clasp/.clasprc.json | sed 's/[^{},:]/*/g')"
+          else
+            echo "::error::~/.config/clasp/.clasprc.json file not found"
+          fi
       
       - name: Setup .clasp.json
         run: |
@@ -48,6 +81,23 @@ jobs:
             "scriptId": "${{ env.SCRIPT_ID }}",
             "rootDir": "./src/apps-script"
           }' > .clasp.json
+          
+      - name: Debug - Verify .clasp.json
+        run: |
+          echo "Contents of .clasp.json:"
+          cat .clasp.json
+          echo ""
+          echo "Current directory: $(pwd)"
+          echo "Directory contents:"
+          ls -la
+      
+      - name: Debug - Check clasp installation
+        run: |
+          echo "Clasp version:"
+          npx clasp --version
+          echo ""
+          echo "Node version: $(node --version)"
+          echo "NPM version: $(npm --version)"
       
       - name: Debug - Check configuration
         run: |


### PR DESCRIPTION
## Summary

This PR fixes two critical issues preventing automated deployments to Google Apps Script:

1. **Authentication failure**: CLASP_CREDENTIALS contained invalid JSON
2. **Read-only deployment**: The deployment ID was for a read-only deployment that couldn't be updated

## Changes

### 1. Fixed JSON Parsing for Credentials
- Added JSON validation and parsing using `jq` 
- Remove potential BOM characters and carriage returns
- Fallback parsing to handle double-quoted JSON
- Copy credentials to both legacy (`~/.clasprc.json`) and new (`~/.config/clasp/.clasprc.json`) locations

### 2. Force Push Without Prompts
- Use `npx clasp push --force` to avoid interactive confirmation prompts

### 3. Handle Read-Only Deployments
- Instead of trying to update the read-only deployment ID, create new versioned deployments
- Add timestamp to deployment descriptions for tracking

## Code Changes

```yaml
# Parse and validate JSON credentials
echo '${{ secrets.CLASP_CREDENTIALS }}' | sed 's/^\xEF\xBB\xBF//' | tr -d '\r' > ~/.clasprc.json.tmp

if jq . ~/.clasprc.json.tmp > ~/.clasprc.json 2>/dev/null; then
  echo "Successfully parsed and formatted JSON"
else
  # Fallback: try removing outer quotes
  echo '${{ secrets.CLASP_CREDENTIALS }}' | sed 's/^"//;s/"$//' | sed 's/^\xEF\xBB\xBF//' | tr -d '\r' > ~/.clasprc.json
fi

# Create new deployments instead of updating read-only ones
npx clasp deploy --description "GitHub Actions deployment $(date +'%Y-%m-%d %H:%M:%S')"
```

## Testing

✅ Authentication now works correctly
✅ Files push successfully to Google Apps Script  
✅ New deployments are created successfully

## Note

The Apps Script API may need to be enabled at https://script.google.com/home/usersettings if not already done.

🤖 Generated with [Claude Code](https://claude.ai/code)