### PR TITLE
fix(ai): progressive sheet writes and fuzzy UUID matching

### DIFF
--- a/src/apps-script/controllers/CategorizationController.ts
+++ b/src/apps-script/controllers/CategorizationController.ts
@@ -161,37 +161,42 @@ export class CategorizationController {
       ]);
     }
 
-    // Perform categorization
+    // Perform categorization with progressive writes to survive Apps Script timeouts
+    let totalCategorized = 0;
+    let totalFailed = 0;
+
     try {
-      const result = await this.categorizer.categorize(toCategorize, categories);
-
-      // Update successfully categorized transactions in sheet
-      for (const transaction of result.categorized) {
-        try {
-          this.sheetAdapter.updateTransactionCategory(
-            transaction.id,
-            transaction.categoryAiId!,
-            transaction.categoryAiName!,
-            false, // Not manual
-            transaction.categoryConfidenceScore ?? undefined
-          );
-        } catch (error) {
-          logger.error(`Failed to update transaction ${transaction.id}`, error as Error);
-          errorMessages.push(`Failed to save category for ${transaction.id}: ${(error as Error).message}`);
+      const result = await this.categorizer.categorize(toCategorize, categories, (batchResult) => {
+        // Write each batch to sheet immediately after AI returns
+        for (const transaction of batchResult.categorized) {
+          try {
+            this.sheetAdapter.updateTransactionCategory(
+              transaction.id,
+              transaction.categoryAiId!,
+              transaction.categoryAiName!,
+              false, // Not manual
+              transaction.categoryConfidenceScore ?? undefined
+            );
+          } catch (error) {
+            logger.error(`Failed to update transaction ${transaction.id}`, error as Error);
+            errorMessages.push(`Failed to save category for ${transaction.id}: ${(error as Error).message}`);
+          }
         }
-      }
 
-      // Log failures
-      for (const failure of result.failed) {
-        logger.error(`Failed to categorize transaction ${failure.transaction.id}: ${failure.error}`);
-        errorMessages.push(failure.error);
-      }
+        for (const failure of batchResult.failed) {
+          logger.error(`Failed to categorize transaction ${failure.transaction.id}: ${failure.error}`);
+          errorMessages.push(failure.error);
+        }
+      });
+
+      totalCategorized = result.categorized.length;
+      totalFailed = result.failed.length;
 
       return this.createResult(
         startTime,
         result.totalProcessed,
-        result.categorized.length,
-        result.failed.length,
+        totalCategorized,
+        totalFailed,
         uncategorized.length - toCategorize.length,
         errorMessages
       );
@@ -253,30 +258,28 @@ export class CategorizationController {
       modifiedAt: new Date()
     }));
 
-    // Perform categorization
+    // Perform categorization with progressive writes
     try {
-      const result = await this.categorizer.categorize(resetTransactions, categories);
-
-      // Update successfully categorized transactions in sheet
-      for (const transaction of result.categorized) {
-        try {
-          this.sheetAdapter.updateTransactionCategory(
-            transaction.id,
-            transaction.categoryAiId!,
-            transaction.categoryAiName!,
-            false,
-            transaction.categoryConfidenceScore ?? undefined
-          );
-        } catch (error) {
-          logger.error(`Failed to update transaction ${transaction.id}`, error as Error);
-          errorMessages.push(`Failed to save category for ${transaction.id}`);
+      const result = await this.categorizer.categorize(resetTransactions, categories, (batchResult) => {
+        for (const transaction of batchResult.categorized) {
+          try {
+            this.sheetAdapter.updateTransactionCategory(
+              transaction.id,
+              transaction.categoryAiId!,
+              transaction.categoryAiName!,
+              false,
+              transaction.categoryConfidenceScore ?? undefined
+            );
+          } catch (error) {
+            logger.error(`Failed to update transaction ${transaction.id}`, error as Error);
+            errorMessages.push(`Failed to save category for ${transaction.id}`);
+          }
         }
-      }
 
-      // Log failures
-      for (const failure of result.failed) {
-        errorMessages.push(failure.error);
-      }
+        for (const failure of batchResult.failed) {
+          errorMessages.push(failure.error);
+        }
+      });
 
       return this.createResult(
         startTime,

--- a/src/apps-script/domain/categorization/AICategorizer.ts
+++ b/src/apps-script/domain/categorization/AICategorizer.ts
@@ -141,7 +141,8 @@ export class AICategorizer {
    */
   async categorize(
     transactions: Transaction[],
-    categories: Category[]
+    categories: Category[],
+    onBatchComplete?: (result: Pick<CategorizationOperationResult, 'categorized' | 'failed'>) => void
   ): Promise<CategorizationOperationResult> {
     // Validate inputs
     this.validateInputs(transactions, categories);
@@ -171,6 +172,11 @@ export class AICategorizer {
         results.categorized.push(...batchResult.categorized);
         results.failed.push(...batchResult.failed);
         results.totalProcessed += batch.length;
+
+        // Persist results progressively so work survives Apps Script timeouts
+        if (onBatchComplete) {
+          onBatchComplete(batchResult);
+        }
       } catch (error) {
         // If entire batch fails, mark all transactions as failed
         batch.forEach(transaction => {

--- a/src/apps-script/infrastructure/adapters/AICategorizationAdapter.ts
+++ b/src/apps-script/infrastructure/adapters/AICategorizationAdapter.ts
@@ -292,10 +292,21 @@ Example response:
     const categoryMap = new Map(categories.map(c => [c.id, c]));
 
     for (const item of parsed) {
-      const transaction = transactionMap.get(item.transactionId);
+      let transaction = transactionMap.get(item.transactionId);
+
+      // LLMs occasionally hallucinate 1-2 characters in UUIDs. With batch sizes ≤10
+      // and 32 hex-char UUIDs, a false positive match at edit distance ≤2 has probability
+      // ≈ 9 × (32×15)² / 16^32 ≈ 0 — effectively impossible.
       if (!transaction) {
-        logger.warning(`AI returned unknown transaction ID: ${item.transactionId}`);
-        continue;
+        const fuzzyMatch = this.findClosestTransactionId(item.transactionId, transactionMap);
+        if (fuzzyMatch) {
+          logger.warning(`AI returned hallucinated transaction ID: ${item.transactionId}, fuzzy-matched to ${fuzzyMatch.id}`);
+          transaction = fuzzyMatch;
+          item.transactionId = fuzzyMatch.id;
+        } else {
+          logger.warning(`AI returned unknown transaction ID: ${item.transactionId}`);
+          continue;
+        }
       }
 
       // Validate category exists
@@ -324,6 +335,44 @@ Example response:
     }
 
     return results;
+  }
+
+  /**
+   * Find the closest transaction ID within edit distance 2.
+   * Returns the matching transaction or undefined if no close match exists.
+   */
+  private findClosestTransactionId(
+    hallucinated: string,
+    transactionMap: Map<string, Transaction>
+  ): Transaction | undefined {
+    for (const [id, transaction] of transactionMap) {
+      if (this.editDistance(hallucinated, id) <= 2) {
+        return transaction;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Calculate Levenshtein edit distance between two strings.
+   * Bails out early if distance exceeds maxDist.
+   */
+  private editDistance(a: string, b: string, maxDist: number = 2): number {
+    if (Math.abs(a.length - b.length) > maxDist) return maxDist + 1;
+
+    const prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+    for (let i = 1; i <= a.length; i++) {
+      let rowMin = i;
+      const curr = [i];
+      for (let j = 1; j <= b.length; j++) {
+        const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+        curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+        if (curr[j] < rowMin) rowMin = curr[j];
+      }
+      if (rowMin > maxDist) return maxDist + 1;
+      prev.splice(0, prev.length, ...curr);
+    }
+    return prev[b.length];
   }
 
   /**


### PR DESCRIPTION
## Summary
- Write categorization results to sheet after each batch (not after all 11k), so progress survives Apps Script's 6-minute timeout
- Add Levenshtein distance matching (≤2) for transaction IDs to recover from LLM UUID hallucinations (e.g. `ac4b` → `ac4d`)
- Add `onBatchComplete` callback to `AICategorizer.categorize()` for progressive persistence

## Test plan
- [ ] Run categorization — verify results appear in sheet progressively (not all at once)
- [ ] If script times out, previously completed batches should be persisted
- [ ] Check logs for "fuzzy-matched" warnings instead of "unknown transaction ID" + "did not categorize"

🤖 Generated with [Claude Code](https://claude.com/claude-code)